### PR TITLE
allow threat score of 0

### DIFF
--- a/src/firewall.ts
+++ b/src/firewall.ts
@@ -363,7 +363,7 @@ class WirefilterFirewallRule implements FirewallRule {
         this.addBoolenToCtx(exec_ctx, 'cf.bot_management.verified_bot', req.cf['cf.bot_management.verified_bot'] ?? false);
         this.addNumberToCtx(exec_ctx, 'cf.bot_management.score', req.cf['cf.bot_management.score'] ?? 100);
         this.addNumberToCtx(exec_ctx, 'cf.client_trust_score', req.cf['cf.client_trust_score'] ?? 100);
-        this.addNumberToCtx(exec_ctx, 'cf.threat_score', req.cf['cf.threat_score'] || 100);
+        this.addNumberToCtx(exec_ctx, 'cf.threat_score', req.cf['cf.threat_score'] ?? 100);
         this.addNumberToCtx(exec_ctx, 'cf.edge.server_port', parsePort(req));
         this.addBoolenToCtx(exec_ctx, 'cf.client.bot', req.cf['cf.client.bot'] ?? false);
         try {

--- a/test/firewall.tests.ts
+++ b/test/firewall.tests.ts
@@ -422,6 +422,9 @@ describe('Dynamic fields', () => {
 
         expect(rule.match(new Request('https://example.org'))).toBeFalsy();
         expect(rule.match(new Request('https://example.org', {
+            cf: {'cf.threat_score': 0}
+        }))).toBeTruthy();
+        expect(rule.match(new Request('https://example.org', {
             cf: {'cf.threat_score': 20}
         }))).toBeTruthy();
     });


### PR DESCRIPTION
👋 thank you for your awesome package 😀

0 is a valid value of threat score - meaning no risk, https://developers.cloudflare.com/firewall/cf-firewall-language/fields#standard-fields

The `||` operator is evaluating to false and using the default high risk value instead.