### PR TITLE
Add apple silicon support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "firewalker",
+  "name": "@tamkelvin313/firewalker",
   "license": "MIT",
-  "version": "1.0.3",
-  "homepage": "https://github.com/SerCeMan/firewalker",
-  "repository": "github:SerCeMan/firewalker",
+  "description": "The clone of [SerCeMan/firewalker](https://github.com/SerCeMan/firewalker), with adding apple silicon support.",
+  "version": "1.0.3.1",
+  "homepage": "https://github.com/tamkelvin313/firewalker",
+  "repository": "github:tamkelvin313/firewalker",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tamkelvin313/firewalker",
   "license": "MIT",
   "description": "The clone of [SerCeMan/firewalker](https://github.com/SerCeMan/firewalker), with adding apple silicon support.",
-  "version": "1.0.3.1",
+  "version": "1.0.4",
   "homepage": "https://github.com/tamkelvin313/firewalker",
   "repository": "github:tamkelvin313/firewalker",
   "main": "dist/index.js",

--- a/src/firewall.ts
+++ b/src/firewall.ts
@@ -174,6 +174,9 @@ export class Firewall {
         switch (process.platform) {
             case 'darwin':
                 libPath = path.join(__dirname, '..', 'lib', 'libwirefilter_ffi.dylib');
+                if (process.arch == 'arm64'){
+                    libPath = path.join(__dirname, '..', 'lib', 'libwirefilter_ffi_aarch64.dylib');
+                }
                 break;
             case 'linux':
                 libPath = path.join(__dirname, '..', 'lib', 'libwirefilter_ffi.so');


### PR DESCRIPTION
Add apple silicon support by compiling binary build  `aarch64-apple-darwin` of [`wirefilter`](https://github.com/cloudflare/wirefilter) 

- Clone the following repo `https://github.com/cloudflare/wirefilter` with commit [2334ab150](https://github.com/cloudflare/wirefilter/commit/2334ab150abd803a555b1541a7e44891b7f5cc60).
- Apply the patch file at npm package [`SerCeMan/firewalker/blob/master/lib/wirefilter.patch`](https://github.com/SerCeMan/firewalker/blob/master/lib/wirefilter.patch)
- Build the `wirefilter` with `aarch64-apple-darwin` architecture. 
```
cargo build --release --target aarch64-apple-darwin
```
- Copy the birary file compiled at last step `wirefilter/target/aarch64-apple-darwin/release/libwirefilter_ffi.dylib` to replace the `node_modules/firewalker/lib/libwirefilter_ffi.dylib`