### PR TITLE
Added new fields to bot management

### DIFF
--- a/src/firewall.ts
+++ b/src/firewall.ts
@@ -226,9 +226,12 @@ export class Firewall {
         addStrArray(wirefilter, scheme, 'http.request.body.form.names');
         addStrArray(wirefilter, scheme, 'http.request.body.form.values');
         // Dynamic fields
+        addBoolen(wirefilter, scheme, 'cf.bot_management.corporate_proxy');
         addString(wirefilter, scheme, 'cf.bot_management.ja3_hash');
         addNumber(wirefilter, scheme, 'cf.bot_management.score');
+        addBoolen(wirefilter, scheme, 'cf.bot_management.static_resource');
         addBoolen(wirefilter, scheme, 'cf.bot_management.verified_bot');
+        addBoolen(wirefilter, scheme, 'cf.bot_management.js_detection.passed');
         addNumber(wirefilter, scheme, 'cf.threat_score');
         addNumber(wirefilter, scheme, 'cf.edge.server_port');
         addBoolen(wirefilter, scheme, 'cf.client.bot');


### PR DESCRIPTION
Added corporate proxy field and other fields missing from https://developers.cloudflare.com/ruleset-engine/rules-language/fields/#dynamic-fields except for `cf.bot_management.detection_ids` as num arrays need more changes