### PR TITLE
Add missing bot/request/waf fields and support new IP field names

### DIFF
--- a/src/firewall.ts
+++ b/src/firewall.ts
@@ -334,7 +334,7 @@ function extractIpInfo(cf: CfRequestExt): IpInfo {
     'ip.src.subdivision_1_iso_code': cf['ip.src.subdivision_1_iso_code'] ?? cf['ip.geoip.subdivision_1_iso_code'],
     'ip.src.subdivision_2_iso_code': cf['ip.src.subdivision_2_iso_code'] ?? cf['ip.geoip.subdivision_2_iso_code'],
     'ip.src.is_in_european_union': cf['ip.src.is_in_european_union'] ?? cf['ip.geoip.is_in_european_union'],
-  }
+  };
 }
 
 type IpInfo = Readonly<{
@@ -481,7 +481,7 @@ class WirefilterFirewallRule implements FirewallRule {
         this.addNumberToCtx(exec_ctx, 'http.request.version', req.cf['http.request.version'] ?? 1);
         this.addStringToCtx(exec_ctx, 'http.x_forwarded_for', req.headers.get('X-Forwarded-For') ?? '');
         // handle duplicated fields for ip info
-        const ipInfo = extractIpInfo(req.cf)
+        const ipInfo = extractIpInfo(req.cf);
         this.addIpAddrToCtx(exec_ctx, 'ip.src', ipInfo['ip.src'] ?? '0.0.0.0');
         this.addStringToCtx(exec_ctx, 'ip.src.lat', ipInfo['ip.src.lat'] ?? '');
         this.addStringToCtx(exec_ctx, 'ip.src.lon', ipInfo['ip.src.lon'] ?? '');

--- a/src/firewall.ts
+++ b/src/firewall.ts
@@ -532,7 +532,7 @@ class WirefilterFirewallRule implements FirewallRule {
         this.addBoolenToCtx(exec_ctx, 'cf.bot_management.verified_bot', req.cf['cf.bot_management.verified_bot'] ?? false);
         this.addBoolenToCtx(exec_ctx, 'cf.bot_management.corporate_proxy', req.cf['cf.bot_management.corporate_proxy'] ?? false);
         this.addBoolenToCtx(exec_ctx, 'cf.bot_management.js_detection.passed', req.cf['cf.bot_management.js_detection.passed'] ?? false);
-        this.addNumArrayCtx(exec_ctx, 'cf.bot_management.detection_ids', req.cf['cf.bot_management.detection_ids'] ?? [0]);
+        this.addNumArrayCtx(exec_ctx, 'cf.bot_management.detection_ids', req.cf['cf.bot_management.detection_ids'] ?? []);
         this.addBoolenToCtx(exec_ctx, 'cf.bot_management.static_resource', req.cf['cf.bot_management.static_resource'] ?? false);
         this.addNumberToCtx(exec_ctx, 'cf.client_trust_score', req.cf['cf.client_trust_score'] ?? 100);
         this.addStringToCtx(exec_ctx, 'cf.ray_id', req.cf['cf.ray_id'] ?? '');

--- a/src/firewall.ts
+++ b/src/firewall.ts
@@ -60,6 +60,15 @@ function addStrArray(wirefilter: any, scheme: any, name: string) {
     ), `Failed to add ${name} to the scheme`);
 }
 
+// Array<Number>
+function addNumArray(wirefilter: any, scheme: any, name: string) {
+    checkAdded(wirefilter.wirefilter_add_type_field_to_scheme(
+        scheme,
+        wirefilterString(name),
+        wirefilter.wirefilter_create_array_type(WIREFILTER_TYPE_INT)
+    ), `Failed to add ${name} to the scheme`);
+}
+
 function addIPList(wirefilter: any, scheme: any, name: string) {
     checkAdded(wirefilter.wirefilter_add_type_list_to_scheme(
         scheme,
@@ -131,6 +140,18 @@ function paramsToMap(params: string): Map<string, string[]> {
     return map;
 }
 
+function parseExtension(path: string): string {
+    const lastSegment = path.split('/').pop() ?? '';
+    const index = lastSegment.lastIndexOf('.');
+    if (index === -1 || index === 0 || index === lastSegment.length-1) {
+        // no extension
+        // Single dot is the first char
+        // No trailing characters
+        return '';
+    }
+    return lastSegment.substr(index+1).toLowerCase();
+}
+
 function paramNamesToArray(params: string): string[] {
     if (params.length == 0) {
         return [];
@@ -155,6 +176,24 @@ function headersToMap(headers: Headers): Map<string, string[]> {
             arr.push(val);
         } else {
             map.set(key, [val]);
+        }
+    });
+    return map;
+}
+
+function cookiesToMap(cookieString: string): Map<string,string[]> {
+    const map = new Map<string, string[]>();
+    cookieString.split(';').map(v => v.split('=')).forEach(val => {
+        // Skip invalid cookies
+        if (val.length === 2) {
+            // Only key is URL decoded
+            const key = decodeURIComponent(val[0].trim());
+            const arr = map.get(key);
+            if (arr) {
+                arr.push(val[1].trim());
+            } else {
+                map.set(key, [val[1].trim()]);
+            }
         }
     });
     return map;
@@ -196,13 +235,28 @@ export class Firewall {
         addString(wirefilter, scheme, 'http.referer');
         addString(wirefilter, scheme, 'http.request.full_uri');
         addString(wirefilter, scheme, 'http.request.method');
+        addMapToStrArray(wirefilter, scheme, 'http.request.cookies');
         addString(wirefilter, scheme, 'http.request.uri');
         addString(wirefilter, scheme, 'http.request.uri.path');
+        addString(wirefilter, scheme, 'http.request.uri.path.extension');
         addString(wirefilter, scheme, 'http.request.uri.query');
         addString(wirefilter, scheme, 'http.user_agent');
         addNumber(wirefilter, scheme, 'http.request.version');
         addString(wirefilter, scheme, 'http.x_forwarded_for');
         addIPaddr(wirefilter, scheme, 'ip.src');
+        addString(wirefilter, scheme, 'ip.src.lat');
+        addString(wirefilter, scheme, 'ip.src.lon');
+        addString(wirefilter, scheme, 'ip.src.city');
+        addString(wirefilter, scheme, 'ip.src.postal_code');
+        addString(wirefilter, scheme, 'ip.src.metro_code');
+        addString(wirefilter, scheme, 'ip.src.region');
+        addString(wirefilter, scheme, 'ip.src.region_code');
+        addNumber(wirefilter, scheme, 'ip.src.asnum');
+        addString(wirefilter, scheme, 'ip.src.continent');
+        addString(wirefilter, scheme, 'ip.src.country');
+        addString(wirefilter, scheme, 'ip.src.subdivision_1_iso_code');
+        addString(wirefilter, scheme, 'ip.src.subdivision_2_iso_code');
+        addBoolen(wirefilter, scheme, 'ip.src.is_in_european_union');
         addNumber(wirefilter, scheme, 'ip.geoip.asnum');
         addString(wirefilter, scheme, 'ip.geoip.continent');
         addString(wirefilter, scheme, 'ip.geoip.country');
@@ -222,18 +276,31 @@ export class Firewall {
         // Body fields
         addString(wirefilter, scheme, 'http.request.body.raw');
         addBoolen(wirefilter, scheme, 'http.request.body.truncated');
+        addNumber(wirefilter, scheme, 'http.request.body.size');
         addMapToStrArray(wirefilter, scheme, 'http.request.body.form');
         addStrArray(wirefilter, scheme, 'http.request.body.form.names');
         addStrArray(wirefilter, scheme, 'http.request.body.form.values');
+        addString(wirefilter, scheme, 'http.request.body.mime');
         // Dynamic fields
         addString(wirefilter, scheme, 'cf.bot_management.ja3_hash');
+        addBoolen(wirefilter, scheme, 'cf.bot_management.js_detection.passed');
+        addNumArray(wirefilter, scheme, 'cf.bot_management.detection_ids');
         addNumber(wirefilter, scheme, 'cf.bot_management.score');
+        addBoolen(wirefilter, scheme, 'cf.bot_management.static_resource');
         addBoolen(wirefilter, scheme, 'cf.bot_management.verified_bot');
         addBoolen(wirefilter, scheme, 'cf.bot_management.corporate_proxy');
+        addString(wirefilter, scheme, 'cf.ray_id');
         addNumber(wirefilter, scheme, 'cf.threat_score');
         addNumber(wirefilter, scheme, 'cf.edge.server_port');
         addBoolen(wirefilter, scheme, 'cf.client.bot');
         addNumber(wirefilter, scheme, 'cf.client_trust_score');
+        addString(wirefilter, scheme, 'cf.verified_bot_category');
+        addNumber(wirefilter, scheme, 'cf.waf.score');
+        addNumber(wirefilter, scheme, 'cf.waf.score.sqli');
+        addNumber(wirefilter, scheme, 'cf.waf.score.xss');
+        addNumber(wirefilter, scheme, 'cf.waf.score.rce');
+        addString(wirefilter, scheme, 'cf.waf.score.class');
+        addString(wirefilter, scheme, 'cf.worker.upstream_zone');
         addIPList(wirefilter, scheme, 'any?');
         this.wirefilter = wirefilter;
         this.scheme = scheme;
@@ -249,6 +316,45 @@ export class Firewall {
     }
 }
 
+// Allows either of the supported fields to be provided but prefer ip.src namespace
+function extractIpInfo(cf: CfRequestExt): IpInfo {
+  return {
+    'ip.src': cf['ip.src'],
+    'ip.src.lat': cf['ip.src.lat'],
+    'ip.src.lon': cf['ip.src.lon'],
+    'ip.src.city': cf['ip.src.city'],
+    'ip.src.postal_code': cf['ip.src.postal_code'],
+    'ip.src.metro_code': cf['ip.src.metro_code'],
+    'ip.src.region': cf['ip.src.region'],
+    'ip.src.region_code': cf['ip.src.region_code'],
+    'ip.src.timezone.name': cf['ip.src.timezone.name'],
+    'ip.src.asnum': cf['ip.src.asnum'] ?? cf['ip.geoip.asnum'],
+    'ip.src.continent': cf['ip.src.continent'] ?? cf['ip.geoip.continent'],
+    'ip.src.country': cf['ip.src.country'] ?? cf['ip.geoip.country'],
+    'ip.src.subdivision_1_iso_code': cf['ip.src.subdivision_1_iso_code'] ?? cf['ip.geoip.subdivision_1_iso_code'],
+    'ip.src.subdivision_2_iso_code': cf['ip.src.subdivision_2_iso_code'] ?? cf['ip.geoip.subdivision_2_iso_code'],
+    'ip.src.is_in_european_union': cf['ip.src.is_in_european_union'] ?? cf['ip.geoip.is_in_european_union'],
+  }
+}
+
+type IpInfo = Readonly<{
+    'ip.src'?: string;
+    'ip.src.lat'?: string;
+    'ip.src.lon'?: string;
+    'ip.src.city'?: string;
+    'ip.src.postal_code'?: string;
+    'ip.src.metro_code'?: string;
+    'ip.src.region'?: string;
+    'ip.src.region_code'?: string;
+    'ip.src.timezone.name'?: string;
+    'ip.src.asnum'?: number;
+    'ip.src.continent'?: string;
+    'ip.src.country'?: string;
+    'ip.src.subdivision_1_iso_code'?: string;
+    'ip.src.subdivision_2_iso_code'?: string;
+    'ip.src.is_in_european_union'?: boolean;
+}>
+
 /**
  * The set of extension fields that can't be directly derived from the supplied request, and need to be specified
  * explicitly.
@@ -256,6 +362,20 @@ export class Firewall {
 export type CfRequestExt = Readonly<{
     'http.request.version'?: number;
     'ip.src'?: string;
+    'ip.src.lat'?: string;
+    'ip.src.lon'?: string;
+    'ip.src.city'?: string;
+    'ip.src.postal_code'?: string;
+    'ip.src.metro_code'?: string;
+    'ip.src.region'?: string;
+    'ip.src.region_code'?: string;
+    'ip.src.timezone.name'?: string;
+    'ip.src.asnum'?: number;
+    'ip.src.continent'?: string;
+    'ip.src.country'?: string;
+    'ip.src.subdivision_1_iso_code'?: string;
+    'ip.src.subdivision_2_iso_code'?: string;
+    'ip.src.is_in_european_union'?: boolean;
     'ip.geoip.asnum'?: number;
     'ip.geoip.continent'?: string;
     'ip.geoip.country'?: string;
@@ -266,11 +386,22 @@ export type CfRequestExt = Readonly<{
     'http.request.body.truncated'?: boolean;
     'cf.bot_management.score'?: number;
     'cf.bot_management.ja3_hash'?: string;
+    'cf.bot_management.js_detection.passed'? : boolean;
+    'cf.bot_management.detection_ids'? : number[];
+    'cf.bot_management.static_resource'? : boolean;
     'cf.bot_management.verified_bot'?: boolean;
     'cf.bot_management.corporate_proxy'?: boolean;
     'cf.client_trust_score'?: number;
+    'cf.ray_id'?: string;
     'cf.threat_score'?: number;
     'cf.client.bot'?: boolean;
+    'cf.verified_bot_category'?: string;
+    'cf.waf.score'?: number;
+    'cf.waf.score.sqli'?: number;
+    'cf.waf.score.xss'?: number;
+    'cf.waf.score.rce'?: number;
+    'cf.waf.score.class'?: string;
+    'cf.worker.upstream_zone'?: string;
 }>;
 
 /**
@@ -301,7 +432,7 @@ export interface FirewallRule {
      *
      * Note, not all of the parameters can be obtained from a request. For instance, thread score, geoip, etc.
      * can't be easily obtained from the request. For such cases, a special cf object can be supplied, e.g. for
-     * 'ip.src, cf: {"ip.scr": '1.2.3.4'} can be used.
+     * 'ip.src, cf: {"ip.src": '1.2.3.4'} can be used.
      *
      * @param req the request which the rule will matched against.
      */
@@ -341,19 +472,36 @@ class WirefilterFirewallRule implements FirewallRule {
         this.addStringToCtx(exec_ctx, 'http.referer', req.headers.get('Referer') ?? '');
         this.addStringToCtx(exec_ctx, 'http.request.full_uri', req.url);
         this.addStringToCtx(exec_ctx, 'http.request.method', req.method);
+        this.addMapStrToCtx(exec_ctx, 'http.request.cookies', cookiesToMap(req.headers.get('Cookie') ?? ''));
         this.addStringToCtx(exec_ctx, 'http.request.uri', `${url.pathname}${url.search}`);
         this.addStringToCtx(exec_ctx, 'http.request.uri.path', url.pathname);
+        this.addStringToCtx(exec_ctx, 'http.request.uri.path.extension', parseExtension(url.pathname));
         this.addStringToCtx(exec_ctx, 'http.request.uri.query', url.searchParams.toString());
         this.addStringToCtx(exec_ctx, 'http.user_agent', req.headers.get('User-Agent') ?? '');
         this.addNumberToCtx(exec_ctx, 'http.request.version', req.cf['http.request.version'] ?? 1);
         this.addStringToCtx(exec_ctx, 'http.x_forwarded_for', req.headers.get('X-Forwarded-For') ?? '');
-        this.addIpAddrToCtx(exec_ctx, 'ip.src', req.cf['ip.src'] ?? '0.0.0.0');
-        this.addNumberToCtx(exec_ctx, 'ip.geoip.asnum', req.cf['ip.geoip.asnum'] ?? 0);
-        this.addStringToCtx(exec_ctx, 'ip.geoip.continent', req.cf['ip.geoip.continent'] ?? '');
-        this.addStringToCtx(exec_ctx, 'ip.geoip.country', req.cf['ip.geoip.country'] ?? '');
-        this.addStringToCtx(exec_ctx, 'ip.geoip.subdivision_1_iso_code', req.cf['ip.geoip.subdivision_1_iso_code'] ?? '');
-        this.addStringToCtx(exec_ctx, 'ip.geoip.subdivision_2_iso_code', req.cf['ip.geoip.subdivision_2_iso_code'] ?? '');
-        this.addBoolenToCtx(exec_ctx, 'ip.geoip.is_in_european_union', req.cf['ip.geoip.is_in_european_union'] ?? false);
+        // handle duplicated fields for ip info
+        const ipInfo = extractIpInfo(req.cf)
+        this.addIpAddrToCtx(exec_ctx, 'ip.src', ipInfo['ip.src'] ?? '0.0.0.0');
+        this.addStringToCtx(exec_ctx, 'ip.src.lat', ipInfo['ip.src.lat'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.src.lon', ipInfo['ip.src.lon'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.src.city', ipInfo['ip.src.city'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.src.postal_code', ipInfo['ip.src.postal_code'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.src.metro_code', ipInfo['ip.src.metro_code'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.src.region', ipInfo['ip.src.region'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.src.region_code', ipInfo['ip.src.region_code'] ?? '');
+        this.addNumberToCtx(exec_ctx, 'ip.src.asnum', ipInfo['ip.src.asnum'] ?? 0);
+        this.addStringToCtx(exec_ctx, 'ip.src.continent', ipInfo['ip.src.continent'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.src.country', ipInfo['ip.src.country'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.src.subdivision_1_iso_code', ipInfo['ip.src.subdivision_1_iso_code'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.src.subdivision_2_iso_code', ipInfo['ip.src.subdivision_2_iso_code'] ?? '');
+        this.addBoolenToCtx(exec_ctx, 'ip.src.is_in_european_union', ipInfo['ip.src.is_in_european_union'] ?? false);
+        this.addNumberToCtx(exec_ctx, 'ip.geoip.asnum', ipInfo['ip.src.asnum'] ?? 0);
+        this.addStringToCtx(exec_ctx, 'ip.geoip.continent', ipInfo['ip.src.continent'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.geoip.country', ipInfo['ip.src.country'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.geoip.subdivision_1_iso_code', ipInfo['ip.src.subdivision_1_iso_code'] ?? '');
+        this.addStringToCtx(exec_ctx, 'ip.geoip.subdivision_2_iso_code', ipInfo['ip.src.subdivision_2_iso_code'] ?? '');
+        this.addBoolenToCtx(exec_ctx, 'ip.geoip.is_in_european_union', ipInfo['ip.src.is_in_european_union'] ?? false);
         this.addBoolenToCtx(exec_ctx, 'ssl', url.protocol === 'https:');
         // Argument and value fields for URIs
         this.addMapStrToCtx(exec_ctx, 'http.request.uri.args', paramsToMap(url.search));
@@ -373,18 +521,31 @@ class WirefilterFirewallRule implements FirewallRule {
         } else {
             bodyParams = new Map<string, string[]>();
         }
+        this.addNumberToCtx(exec_ctx, 'http.request.body.size', String(req.body ?? '').length);
         this.addMapStrToCtx(exec_ctx, 'http.request.body.form', bodyParams);
         this.addStrArrayCtx(exec_ctx, 'http.request.body.form.names', [...bodyParams.keys()]);
         this.addStrArrayCtx(exec_ctx, 'http.request.body.form.values', ([] as string[]).concat(...bodyParams.values()));
+        this.addStringToCtx(exec_ctx, 'http.request.body.mime', req.headers.get('Content-Type') ?? '');
         // Dynamic fields
         this.addStringToCtx(exec_ctx, 'cf.bot_management.ja3_hash', req.cf['cf.bot_management.ja3_hash'] ?? '');
         this.addNumberToCtx(exec_ctx, 'cf.bot_management.score', req.cf['cf.bot_management.score'] ?? 100);
         this.addBoolenToCtx(exec_ctx, 'cf.bot_management.verified_bot', req.cf['cf.bot_management.verified_bot'] ?? false);
         this.addBoolenToCtx(exec_ctx, 'cf.bot_management.corporate_proxy', req.cf['cf.bot_management.corporate_proxy'] ?? false);
+        this.addBoolenToCtx(exec_ctx, 'cf.bot_management.js_detection.passed', req.cf['cf.bot_management.js_detection.passed'] ?? false);
+        this.addNumArrayCtx(exec_ctx, 'cf.bot_management.detection_ids', req.cf['cf.bot_management.detection_ids'] ?? [0]);
+        this.addBoolenToCtx(exec_ctx, 'cf.bot_management.static_resource', req.cf['cf.bot_management.static_resource'] ?? false);
         this.addNumberToCtx(exec_ctx, 'cf.client_trust_score', req.cf['cf.client_trust_score'] ?? 100);
+        this.addStringToCtx(exec_ctx, 'cf.ray_id', req.cf['cf.ray_id'] ?? '');
         this.addNumberToCtx(exec_ctx, 'cf.threat_score', req.cf['cf.threat_score'] ?? 100);
         this.addNumberToCtx(exec_ctx, 'cf.edge.server_port', parsePort(req));
         this.addBoolenToCtx(exec_ctx, 'cf.client.bot', req.cf['cf.client.bot'] ?? false);
+        this.addStringToCtx(exec_ctx, 'cf.verified_bot_category', req.cf['cf.verified_bot_category'] ?? '');
+        this.addNumberToCtx(exec_ctx, 'cf.waf.score', req.cf['cf.waf.score'] ?? 100);
+        this.addNumberToCtx(exec_ctx, 'cf.waf.score.sqli', req.cf['cf.waf.score.sqli'] ?? 100);
+        this.addNumberToCtx(exec_ctx, 'cf.waf.score.xss', req.cf['cf.waf.score.xss'] ?? 100);
+        this.addNumberToCtx(exec_ctx, 'cf.waf.score.rce', req.cf['cf.waf.score.rce'] ?? 100);
+        this.addStringToCtx(exec_ctx, 'cf.waf.score.class', req.cf['cf.waf.score.class'] ?? '');
+        this.addStringToCtx(exec_ctx, 'cf.worker.upstream_zone', req.cf['cf.worker.upstream_zone'] ?? '');
         // IP Lists
         checkAdded(this.wirefilter.set_nevermatch_iplist(exec_ctx), 'can\'t add nevermatch list');
         try {
@@ -474,6 +635,22 @@ class WirefilterFirewallRule implements FirewallRule {
                 arr,
                 ind,
                 wirefilterByteArray(val)
+            ), `Failed to add a ${val} to array`);
+        });
+        checkAdded(this.wirefilter.wirefilter_add_array_value_to_execution_context(
+            execCtx,
+            wirefilterString(name),
+            arr,
+        ), `Failed to add ${name}=${JSON.stringify(value)} to the context`);
+    }
+
+    private addNumArrayCtx(execCtx: any, name: string, value: number[]) {
+        const arr = this.wirefilter.wirefilter_create_array(WIREFILTER_TYPE_INT);
+        value.forEach((val, ind) => {
+            checkAdded(this.wirefilter.wirefilter_add_int_value_to_array(
+                arr,
+                ind,
+                val,
             ), `Failed to add a ${val} to array`);
         });
         checkAdded(this.wirefilter.wirefilter_add_array_value_to_execution_context(

--- a/test/firewall.tests.ts
+++ b/test/firewall.tests.ts
@@ -12,12 +12,12 @@ describe('Standard fields', () => {
 
     it('should match the entire cookie as a string', () => {
         const rule = firewall.createRule(`
-            http.cookie != "gingersnaps=true"
+            http.cookie != "gingersnaps"
         `);
 
         expect(rule.match(new Request('http://example.org'))).toBeTruthy();
         expect(rule.match(new Request('http://example.org', {
-            headers: [['Cookie', 'gingersnaps=true']]
+            headers: [['Cookie', 'gingersnaps']]
         }))).toBeFalsy();
         expect(rule.match(new Request('http://example.org', {
             headers: [['Cookie', 'oatmeal=false']]


### PR DESCRIPTION
# Changes
## IP field changes
the rules language has soft deprecated most of the `ip.geoip.*` fields in favour of `ip.src` namespaced fields. This PR adds all the new fields and allows users to pass in values using either name and still have both fields populated in the output. Have given priority to `ip.src` if both are set. 

## New fields
Adds various fields that have been added to the ruleset engine over time that seemed handy to have access to. 
Omitted `cf.tls_client_auth` related ones as they didn't seem too useful to have but can add in another PR if desired. 
`ip.src` ones are all renames of the existing `ip.geoip` fields.
- `http.request.cookies`
- `http.request.uri.path.extension`
- `http.request.body.size`
- `http.request.body.mime`
- `ip.src.lat`
- `ip.src.lon`
- `ip.src.city`
- `ip.src.postal_code`
- `ip.src.metro_code`
- `ip.src.region`
- `ip.src.region_code`
- `ip.src.timezone.name`
- `ip.src.asnum`
- `ip.src.continent`
- `ip.src.country`
- `ip.src.subdivision_1_iso_code`
- `ip.src.subdivision_2_iso_code`
- `ip.src.is_in_european_union`
- `cf.bot_management.js_detection.passed`
- `cf.bot_management.detection_ids`
- `cf.bot_management.static_resource`
- `cf.ray_id`
- `cf.verified_bot_category`
- `cf.waf.score`
- `cf.waf.score.sqli`
- `cf.waf.score.xss`
- `cf.waf.score.rce`
- `cf.waf.score.class`
- `cf.worker.upstream_zone`

## Tests
All new fields have had tests added or updated to ensure coverage