### PR TITLE
Implement rulesets for testing multiple rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ rule.match(new Request('http://www.example.com')) // -> false
 
 See more [examples](https://github.com/SerCeMan/firewalker/blob/master/test/firewall.tests.ts).
 
-And for integration testsing see some of the [ruleset examples](https://github.com/SerCeMan/firewalker/blob/master/test/ruleset.tests.ts)
+And for integration testing see some of the [ruleset examples](https://github.com/SerCeMan/firewalker/blob/master/test/ruleset.tests.ts)
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ rule.match(new Request('http://www.example.com')) // -> false
 
 See more [examples](https://github.com/SerCeMan/firewalker/blob/master/test/firewall.tests.ts).
 
+And for integration testsing see some of the [ruleset examples](https://github.com/SerCeMan/firewalker/blob/master/test/ruleset.tests.ts)
+
 ## Motivation
 
 It's easy to treat firewall rules as plain configuration. It's incredibly easy to manage a couple of rules that look like.
 ```
-http.host eq "www.example.org" 
+http.host eq "www.example.org"
 ```
 
-And end up with a rule that looks more like. 
+And end up with a rule that looks more like.
 ```wireshark
 http.host matches "(www|api)\.example\.org"
 and not lower(http.request.uri.path) matches "/(auth|login|logut).*"
@@ -35,9 +37,9 @@ and (
   ip.src in { 93.184.216.34 62.122.170.171 }
 )
 or cf.threat_score lt 10
-``` 
+```
 
-Over time, the number of rules and their complexity grows. Manually testing rules like the above is error-prone as humans are known to make mistakes. After a few steps up in complexity, it becomes apparent that firewall rules are code, and need to be treated as code. They need to be stored in a source code repository, managed with a tool like Terraform, and the changes need to be tested on CI. 
+Over time, the number of rules and their complexity grows. Manually testing rules like the above is error-prone as humans are known to make mistakes. After a few steps up in complexity, it becomes apparent that firewall rules are code, and need to be treated as code. They need to be stored in a source code repository, managed with a tool like Terraform, and the changes need to be tested on CI.
 
 Here is where Firewalker comes into play allowing you to write unit tests to ensure that a change to the path regex isn't going to block all of the traffic to your site or cancel out the effect of the rule completely. For instance, for the rule above, you can define multiple assertions with jest.
 

--- a/src/firewall.ts
+++ b/src/firewall.ts
@@ -514,7 +514,7 @@ type RulesetMatchResult = {
     skippedProducts: Set<Product>
     outcome:
     | {
-        action: | 'allow'
+        action: 'no_match'
     }
     | {
         id: string
@@ -563,7 +563,7 @@ export class FirewallRuleset {
             loggedRules: [],
             skippedPhases: new Set(),
             skippedProducts: new Set(),
-            outcome: { action: 'allow' },
+            outcome: { action: 'no_match' },
         };
         const execCtx = ExecutionContext.buildFromRequest(this.wirefilter, this.scheme, this.defaultLists, request);
         try {

--- a/test/ruleset.tests.ts
+++ b/test/ruleset.tests.ts
@@ -85,7 +85,20 @@ describe('Multi-rule testing', () => {
         const result = ruleset.matchRequest(request);
         expect(result.terminatedEarly).toBeTruthy();
         expect(result.terminalAction).toMatchObject({
-            action: { type: 'no_match', },
+            action: { type: 'skip' },
+        });
+    });
+
+    it('non-matching request reports no match', () => {
+        const request = new Request('http://example.org/', {
+            headers: [
+                ['Cookie', 'gingersnaps'],
+            ]
+        });
+        const result = ruleset.matchRequest(request);
+        expect(result.terminatedEarly).toBeFalsy();
+        expect(result.terminalAction).toMatchObject({
+            action: { type: 'no_match' }
         });
     });
 
@@ -150,6 +163,7 @@ describe('rules with lists', () => {
     it('challenges when not in lists', () => {
         const request = new Request('https://example.org');
         const result = ruleset.matchRequest(request);
+        expect(result.terminatedEarly).toBeTruthy();
         expect(result.terminalAction).toMatchObject({
             ruleId: 'challengeRemaining',
             action: { type: 'managed_challenge', }
@@ -159,14 +173,16 @@ describe('rules with lists', () => {
     it('bypasses when asn in list', () => {
         const request = new Request('https://example.org', { cf: { 'ip.geoip.asnum': 123 } });
         const result = ruleset.matchRequest(request);
+        expect(result.terminatedEarly).toBeTruthy();
         expect(result.terminalAction).toMatchObject({
-            action: { type: 'no_match', }
+            action: { type: 'skip', }
         });
     });
 
     it('blocks bad asn', () => {
         const request = new Request('https://example.org', { cf: { 'ip.geoip.asnum': 456 } });
         const result = ruleset.matchRequest(request);
+        expect(result.terminatedEarly).toBeTruthy();
         expect(result.terminalAction).toMatchObject({
             ruleId: 'blockAsns',
             action: { type: 'block', }
@@ -176,14 +192,16 @@ describe('rules with lists', () => {
     it('bypasses when ip in list', () => {
         const request = new Request('https://example.org', { cf: { 'ip.src': '10.0.0.1' } });
         const result = ruleset.matchRequest(request);
+        expect(result.terminatedEarly).toBeTruthy();
         expect(result.terminalAction).toMatchObject({
-            action: { type: 'no_match', }
+            action: { type: 'skip', }
         });
     });
 
     it('blocks bad asn', () => {
         const request = new Request('https://example.org', { cf: { 'ip.src': '11.0.0.1' } });
         const result = ruleset.matchRequest(request);
+        expect(result.terminatedEarly).toBeTruthy();
         expect(result.terminalAction).toMatchObject({
             ruleId: 'blockIps',
             action: { type: 'block', }

--- a/test/ruleset.tests.ts
+++ b/test/ruleset.tests.ts
@@ -87,7 +87,7 @@ describe('Multi-rule testing', () => {
         });
         expect(ruleset.matchRequest(request)).toMatchObject({
             outcome: {
-                action: 'allow',
+                action: 'no_match',
             }
         });
     });
@@ -164,7 +164,7 @@ describe('rules with lists', () => {
         const request = new Request('https://example.org', { cf: { 'ip.geoip.asnum': 123 } });
         expect(ruleset.matchRequest(request)).toMatchObject({
             outcome: {
-                action: 'allow',
+                action: 'no_match',
             }
         });
     });
@@ -183,7 +183,7 @@ describe('rules with lists', () => {
         const request = new Request('https://example.org', { cf: { 'ip.src': '10.0.0.1' } });
         expect(ruleset.matchRequest(request)).toMatchObject({
             outcome: {
-                action: 'allow',
+                action: 'no_match',
             }
         });
     });

--- a/test/ruleset.tests.ts
+++ b/test/ruleset.tests.ts
@@ -1,0 +1,200 @@
+import { Firewall, Request } from '../src';
+import { FirewallRuleset } from '../src/firewall';
+
+const firewall = new Firewall();
+let ruleset: FirewallRuleset;
+
+beforeEach(() => {
+    ruleset = firewall.createRuleSet();
+});
+
+describe('Multi-rule testing', () => {
+    beforeEach(() => {
+        ruleset
+            .addRule({
+                id: 'blockCookies',
+                expression: 'http.cookie != "gingersnaps"',
+                action: { type: 'block' }
+            })
+            .addRule({
+                id: 'logReferrers',
+                expression: 'http.referer eq "https://developer.example.org/en-US"',
+                action: { type: 'log' }
+            })
+            .addRule({
+                id: 'fooSkips',
+                expression: 'http.request.uri.path eq "/test/foo"',
+                action: { type: 'skip', ruleset: 'current' }
+            })
+            .addRule({
+                id: 'barSkips',
+                expression: 'http.request.uri.path eq "/test/bar"',
+                action: { type: 'skip', phases: ['http_ratelimit'], products: ['bic'] }
+            })
+            .addRule({
+                id: 'testChallenges',
+                expression: 'http.request.uri.path matches "^/test/.*"',
+                action: { type: 'managed_challenge' },
+            });
+    });
+
+    it('blocks expected request without cookie', () => {
+        const request = new Request('http://example.org', {
+            headers: [
+                ['Cookie', 'oatmeal'],
+                ['Referer', 'https://developer.example.org/en-US'],
+            ]
+        });
+        expect(ruleset.matchRequest(request)).toMatchObject({
+            outcome: {
+                id: 'blockCookies',
+                action: 'block',
+            }
+        });
+    });
+
+    it('logs rules in results', () => {
+        const request = new Request('http://example.org/', {
+            headers: [
+                ['Cookie', 'gingersnaps'],
+                ['Referer', 'https://developer.example.org/en-US'],
+            ]
+        });
+        expect(ruleset.matchRequest(request)).toMatchObject({
+            loggedRules: ['logReferrers']
+        });
+    });
+
+    it('challenges as expected', () => {
+        const request = new Request('http://example.org/test/baz', {
+            headers: [
+                ['Cookie', 'gingersnaps'],
+            ]
+        });
+        expect(ruleset.matchRequest(request)).toMatchObject({
+            outcome: {
+                id: 'testChallenges',
+                action: 'managed_challenge'
+            }
+        });
+    });
+
+    it('skip current ruleset works as expected', () => {
+        const request = new Request('http://example.org/test/foo', {
+            headers: [
+                ['Cookie', 'gingersnaps'],
+            ]
+        });
+        expect(ruleset.matchRequest(request)).toMatchObject({
+            outcome: {
+                action: 'allow',
+            }
+        });
+    });
+
+    it('skips phases and products works as expected', () => {
+        const request = new Request('http://example.org/test/bar', {
+            headers: [
+                ['Cookie', 'gingersnaps'],
+            ]
+        });
+        const result = ruleset.matchRequest(request);
+        expect(result.skippedPhases).toContain('http_ratelimit');
+        expect(result.skippedProducts).toContain('bic');
+    });
+});
+
+describe('rules with lists', () => {
+    beforeEach(() => {
+        ruleset
+            .setDefaultLists({
+                int: {
+                    'bypass_asns': [123],
+                    'bad_asns': [456],
+                },
+                ip: {
+                    'bypass_ips': ['10.0.0.1'],
+                    'bad_ips': ['11.0.0.1'],
+                }
+            })
+            .addRule({
+                id: 'bypassAsns',
+                expression: 'ip.geoip.asnum in $bypass_asns',
+                action: {
+                    type: 'skip',
+                    ruleset: 'current',
+                }
+            })
+            .addRule({
+                id: 'blockAsns',
+                expression: 'ip.geoip.asnum in $bad_asns',
+                action: { type: 'block' },
+            })
+            .addRule({
+                id: 'bypassIps',
+                expression: 'ip.src in $bypass_ips',
+                action: {
+                    type: 'skip',
+                    ruleset: 'current',
+                }
+            })
+            .addRule({
+                id: 'blockIps',
+                expression: 'ip.src in $bad_ips',
+                action: { type: 'block' },
+            })
+            .addRule({
+                id: 'challengeRemaining',
+                expression: 'http.request.uri.path matches "^/"',
+                action: { type: 'managed_challenge' }
+            });
+    });
+
+    it('challenges when not in lists', () => {
+        const request = new Request('https://example.org');
+        expect(ruleset.matchRequest(request)).toMatchObject({
+            outcome: {
+                id: 'challengeRemaining',
+                action: 'managed_challenge',
+            }
+        });
+    });
+
+    it('bypasses when asn in list', () => {
+        const request = new Request('https://example.org', { cf: { 'ip.geoip.asnum': 123 } });
+        expect(ruleset.matchRequest(request)).toMatchObject({
+            outcome: {
+                action: 'allow',
+            }
+        });
+    });
+
+    it('blocks bad asn', () => {
+        const request = new Request('https://example.org', { cf: { 'ip.geoip.asnum': 456 } });
+        expect(ruleset.matchRequest(request)).toMatchObject({
+            outcome: {
+                id: 'blockAsns',
+                action: 'block',
+            }
+        });
+    });
+
+    it('bypasses when ip in list', () => {
+        const request = new Request('https://example.org', { cf: { 'ip.src': '10.0.0.1' } });
+        expect(ruleset.matchRequest(request)).toMatchObject({
+            outcome: {
+                action: 'allow',
+            }
+        });
+    });
+
+    it('blocks bad asn', () => {
+        const request = new Request('https://example.org', { cf: { 'ip.src': '11.0.0.1' } });
+        expect(ruleset.matchRequest(request)).toMatchObject({
+            outcome: {
+                id: 'blockIps',
+                action: 'block',
+            }
+        });
+    });
+});

--- a/test/ruleset.tests.ts
+++ b/test/ruleset.tests.ts
@@ -45,11 +45,10 @@ describe('Multi-rule testing', () => {
                 ['Referer', 'https://developer.example.org/en-US'],
             ]
         });
-        expect(ruleset.matchRequest(request)).toMatchObject({
-            outcome: {
-                id: 'blockCookies',
-                action: 'block',
-            }
+        const result = ruleset.matchRequest(request);
+        expect(result.terminalAction).toMatchObject({
+            ruleId: 'blockCookies',
+            action: { type: 'block', },
         });
     });
 
@@ -60,9 +59,8 @@ describe('Multi-rule testing', () => {
                 ['Referer', 'https://developer.example.org/en-US'],
             ]
         });
-        expect(ruleset.matchRequest(request)).toMatchObject({
-            loggedRules: ['logReferrers']
-        });
+        const result = ruleset.matchRequest(request);
+        expect(result.loggedRules).toStrictEqual(['logReferrers']);
     });
 
     it('challenges as expected', () => {
@@ -71,11 +69,10 @@ describe('Multi-rule testing', () => {
                 ['Cookie', 'gingersnaps'],
             ]
         });
-        expect(ruleset.matchRequest(request)).toMatchObject({
-            outcome: {
-                id: 'testChallenges',
-                action: 'managed_challenge'
-            }
+        const result = ruleset.matchRequest(request);
+        expect(result.terminalAction).toMatchObject({
+            ruleId: 'testChallenges',
+            action: { type: 'managed_challenge' },
         });
     });
 
@@ -85,10 +82,10 @@ describe('Multi-rule testing', () => {
                 ['Cookie', 'gingersnaps'],
             ]
         });
-        expect(ruleset.matchRequest(request)).toMatchObject({
-            outcome: {
-                action: 'no_match',
-            }
+        const result = ruleset.matchRequest(request);
+        expect(result.terminatedEarly).toBeTruthy();
+        expect(result.terminalAction).toMatchObject({
+            action: { type: 'no_match', },
         });
     });
 
@@ -152,49 +149,44 @@ describe('rules with lists', () => {
 
     it('challenges when not in lists', () => {
         const request = new Request('https://example.org');
-        expect(ruleset.matchRequest(request)).toMatchObject({
-            outcome: {
-                id: 'challengeRemaining',
-                action: 'managed_challenge',
-            }
+        const result = ruleset.matchRequest(request);
+        expect(result.terminalAction).toMatchObject({
+            ruleId: 'challengeRemaining',
+            action: { type: 'managed_challenge', }
         });
     });
 
     it('bypasses when asn in list', () => {
         const request = new Request('https://example.org', { cf: { 'ip.geoip.asnum': 123 } });
-        expect(ruleset.matchRequest(request)).toMatchObject({
-            outcome: {
-                action: 'no_match',
-            }
+        const result = ruleset.matchRequest(request);
+        expect(result.terminalAction).toMatchObject({
+            action: { type: 'no_match', }
         });
     });
 
     it('blocks bad asn', () => {
         const request = new Request('https://example.org', { cf: { 'ip.geoip.asnum': 456 } });
-        expect(ruleset.matchRequest(request)).toMatchObject({
-            outcome: {
-                id: 'blockAsns',
-                action: 'block',
-            }
+        const result = ruleset.matchRequest(request);
+        expect(result.terminalAction).toMatchObject({
+            ruleId: 'blockAsns',
+            action: { type: 'block', }
         });
     });
 
     it('bypasses when ip in list', () => {
         const request = new Request('https://example.org', { cf: { 'ip.src': '10.0.0.1' } });
-        expect(ruleset.matchRequest(request)).toMatchObject({
-            outcome: {
-                action: 'no_match',
-            }
+        const result = ruleset.matchRequest(request);
+        expect(result.terminalAction).toMatchObject({
+            action: { type: 'no_match', }
         });
     });
 
     it('blocks bad asn', () => {
         const request = new Request('https://example.org', { cf: { 'ip.src': '11.0.0.1' } });
-        expect(ruleset.matchRequest(request)).toMatchObject({
-            outcome: {
-                id: 'blockIps',
-                action: 'block',
-            }
+        const result = ruleset.matchRequest(request);
+        expect(result.terminalAction).toMatchObject({
+            ruleId: 'blockIps',
+            action: { type: 'block', }
         });
     });
 });


### PR DESCRIPTION
To enable integration testing of multiple rules this PR adds a new ruleset class. This allows adding an ordered list of rules and actions to take, which aims to follow a simplified version of cloudflares custom waf rules. 