### PR TITLE
Export FirewallRuleset Class for module use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export {
     Firewall,
     FirewallRule,
+    FirewallRuleset,
     Request
 } from './firewall';


### PR DESCRIPTION
Rulesets were recently added, and it appears the class was not exported. Attempting to use them results in the following error: '"firewalker"' has no exported member named 'FirewallRuleset'. Did you mean 'FirewallRule'?